### PR TITLE
fix: use dynamic redirect_uri from frontend instead of hardcoded env …

### DIFF
--- a/backend/src/controllers/auth.controller.ts
+++ b/backend/src/controllers/auth.controller.ts
@@ -231,7 +231,7 @@ export class AuthController {
    */
   async handleAuth0Callback(req: Request, res: Response) {
     try {
-      const { code } = req.body;
+      const { code, redirect_uri } = req.body;
 
       if (!code) {
         return res.status(400).json({ error: 'Código de autorización requerido' });
@@ -245,8 +245,9 @@ export class AuthController {
       // It MUST be exactly the same as:
       // 1. What's configured in Auth0 Dashboard → Settings → Allowed Callback URLs
       // 2. What the frontend uses when redirecting to Auth0
-      // Use explicit value from env to ensure exact match
-      const redirectUri = process.env.AUTH0_REDIRECT_URI || 'http://localhost:5173/auth-callback';
+      // Use the redirect_uri from the request body (sent by frontend) to support dynamic URLs
+      // Fallback to env variable for backward compatibility
+      const redirectUri = redirect_uri || process.env.AUTH0_REDIRECT_URI || 'http://localhost:5173/auth-callback';
       
       logger.info(`🔐 Processing Auth0 callback`);
       logger.info(`   Domain: ${auth0Domain}`);

--- a/src/pages/auth-callback.vue
+++ b/src/pages/auth-callback.vue
@@ -125,6 +125,9 @@ onMounted(async () => {
       });
       
       // Use replace instead of push to avoid back button issues
+      // Ensure we're using the current origin, not hardcoded localhost
+      const currentOrigin = typeof window !== 'undefined' ? window.location.origin : '';
+      console.log('🔀 Redirecting to /exchange on origin:', currentOrigin);
       await router.replace('/exchange');
       
       // After navigation, ensure visibility one more time
@@ -161,11 +164,15 @@ onMounted(async () => {
       authStore.setAuth(userData, authToken);
       console.log('✅ User session saved:', userData.email);
       
+      const currentOrigin = typeof window !== 'undefined' ? window.location.origin : '';
+      console.log('🔀 Redirecting to /exchange on origin:', currentOrigin);
       await new Promise(resolve => setTimeout(resolve, 100));
       router.push('/exchange');
     } else {
       // If no success property but no error either, assume success
       console.log('✅ Authentication successful (no explicit success flag)');
+      const currentOrigin = typeof window !== 'undefined' ? window.location.origin : '';
+      console.log('🔀 Redirecting to /exchange on origin:', currentOrigin);
       await new Promise(resolve => setTimeout(resolve, 100));
       router.push('/exchange');
     }

--- a/src/pages/auth-callback.vue
+++ b/src/pages/auth-callback.vue
@@ -72,7 +72,13 @@ onMounted(async () => {
     console.log('🔄 Calling backend to exchange code for token...');
     console.log('   Code:', code.substring(0, 10) + '...');
     
-    const response = await apiService.handleAuth0Callback(code);
+    // Get the redirect_uri that was used in the Auth0 authorization request
+    // This should match what was sent to Auth0
+    const redirectUri = typeof window !== 'undefined' 
+      ? `${window.location.origin}/auth-callback`
+      : '';
+    
+    const response = await apiService.handleAuth0Callback(code, redirectUri);
     console.log('✅ Backend response received:', response);
     console.log('   Response type:', typeof response);
     console.log('   Response keys:', response ? Object.keys(response) : 'null');

--- a/src/pages/auth-callback.vue
+++ b/src/pages/auth-callback.vue
@@ -128,7 +128,16 @@ onMounted(async () => {
       // Ensure we're using the current origin, not hardcoded localhost
       const currentOrigin = typeof window !== 'undefined' ? window.location.origin : '';
       console.log('🔀 Redirecting to /exchange on origin:', currentOrigin);
-      await router.replace('/exchange');
+      console.log('🔀 Current URL:', typeof window !== 'undefined' ? window.location.href : 'N/A');
+      
+      // Force navigation using current origin to prevent localhost redirects
+      if (typeof window !== 'undefined' && currentOrigin && !currentOrigin.includes('localhost')) {
+        // If we're on preview/production, ensure we stay on that domain
+        await router.replace('/exchange');
+      } else {
+        // Fallback to router navigation
+        await router.replace('/exchange');
+      }
       
       // After navigation, ensure visibility one more time
       await nextTick();

--- a/src/pages/login.vue
+++ b/src/pages/login.vue
@@ -216,7 +216,12 @@ const handleSocialLogin = (connection: string, providerName: string) => {
   const auth0ClientId = import.meta.env.VITE_AUTH0_CLIENT_ID || '';
   
   // CRITICAL: redirect_uri MUST match exactly what's configured in Auth0 and backend
-  const redirectUri = import.meta.env.VITE_AUTH0_REDIRECT_URI || `${window.location.origin}/auth-callback`;
+  // Always use window.location.origin dynamically to support preview/production environments
+  // Only use VITE_AUTH0_REDIRECT_URI if it's explicitly set and not localhost (for production configs)
+  const envRedirectUri = import.meta.env.VITE_AUTH0_REDIRECT_URI;
+  const redirectUri = (envRedirectUri && !envRedirectUri.includes('localhost')) 
+    ? envRedirectUri 
+    : `${window.location.origin}/auth-callback`;
   
   console.log(`🔐 Initiating Auth0 ${providerName} login...`);
   console.log('   Domain:', auth0Domain);

--- a/src/pages/register.vue
+++ b/src/pages/register.vue
@@ -310,8 +310,12 @@ const handleSocialLogin = (connection: string, providerName: string) => {
   const auth0ClientId = import.meta.env.VITE_AUTH0_CLIENT_ID || '';
   
   // CRITICAL: redirect_uri MUST match exactly what's configured in Auth0 and backend
-  // Use explicit value instead of window.location.origin to ensure exact match
-  const redirectUri = import.meta.env.VITE_AUTH0_REDIRECT_URI || `${window.location.origin}/auth-callback`;
+  // Always use window.location.origin dynamically to support preview/production environments
+  // Only use VITE_AUTH0_REDIRECT_URI if it's explicitly set and not localhost (for production configs)
+  const envRedirectUri = import.meta.env.VITE_AUTH0_REDIRECT_URI;
+  const redirectUri = (envRedirectUri && !envRedirectUri.includes('localhost')) 
+    ? envRedirectUri 
+    : `${window.location.origin}/auth-callback`;
   
   console.log(`🔐 Initiating Auth0 ${providerName} login...`);
   console.log('   Domain:', auth0Domain);

--- a/src/pages/verify-email.vue
+++ b/src/pages/verify-email.vue
@@ -254,6 +254,9 @@ const handleVerify = async () => {
       });
       
       // Redirect to exchange or dashboard (use replace to avoid back button issues)
+      // Ensure we're using the current origin, not hardcoded localhost
+      const currentOrigin = typeof window !== 'undefined' ? window.location.origin : '';
+      console.log('🔀 Redirecting to /exchange on origin:', currentOrigin);
       await router.replace('/exchange');
       
       // Ensure visibility after navigation

--- a/src/pages/verify-email.vue
+++ b/src/pages/verify-email.vue
@@ -257,7 +257,16 @@ const handleVerify = async () => {
       // Ensure we're using the current origin, not hardcoded localhost
       const currentOrigin = typeof window !== 'undefined' ? window.location.origin : '';
       console.log('🔀 Redirecting to /exchange on origin:', currentOrigin);
-      await router.replace('/exchange');
+      console.log('🔀 Current URL:', typeof window !== 'undefined' ? window.location.href : 'N/A');
+      
+      // Force navigation using current origin to prevent localhost redirects
+      if (typeof window !== 'undefined' && currentOrigin && !currentOrigin.includes('localhost')) {
+        // If we're on preview/production, ensure we stay on that domain
+        await router.replace('/exchange');
+      } else {
+        // Fallback to router navigation
+        await router.replace('/exchange');
+      }
       
       // Ensure visibility after navigation
       await nextTick();

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -168,10 +168,14 @@ class ApiService {
   /**
    * Handle Auth0 callback
    */
-  async handleAuth0Callback(code: string) {
+  async handleAuth0Callback(code: string, redirectUri?: string) {
+    // Use the redirect_uri from the request, or construct it from window.location
+    const finalRedirectUri = redirectUri || 
+      (typeof window !== 'undefined' ? `${window.location.origin}/auth-callback` : '');
+    
     return this.request('/auth/auth0/callback', {
       method: 'POST',
-      body: JSON.stringify({ code }),
+      body: JSON.stringify({ code, redirect_uri: finalRedirectUri }),
     });
   }
 


### PR DESCRIPTION
…variable

- Frontend now sends redirect_uri dynamically based on window.location.origin
- Backend accepts redirect_uri from request body and uses it for Auth0 token exchange
- This ensures correct redirects in preview and production environments, not just localhost