### PR TITLE
EX-3-]----Flujo-de-Orden-de-Venta

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,3 +6,11 @@
 VITE_BANK_BENEFICIARY=Nombre del beneficiario
 VITE_BANK_IBAN=MT00XXXX00000000000000000000000
 VITE_BANK_NAME=Nombre del banco
+
+# Wallets de depósito de Exury (sell flow). FUENTE PREFERIDA: backend
+# (EXURY_DEPOSIT_WALLETS_JSON) vía GET /v1/deposit-wallets. Esta var es un
+# fallback opcional para desarrollo local cuando no se quiere levantar el backend.
+# Formato (JSON en una sola línea): { "USDC": [ {"value":"bsc","label":"BSC (BEP20)","address":"0x..."} ], ... }
+# Deja el valor vacío en producción; las direcciones reales sólo deben vivir
+# en la variable del backend (no viajan al bundle del cliente).
+VITE_EXURY_DEPOSIT_WALLETS_JSON=

--- a/src/components/PriceSimulatorInline.vue
+++ b/src/components/PriceSimulatorInline.vue
@@ -771,6 +771,28 @@ const handleContinue = async () => {
         /* ignore */
       }
       try {
+        // Sólo en compra: adjuntamos la wallet de destino que el usuario guardó.
+        // El backend hace upsert en user_wallets (si no existía) y guarda user_wallet_id
+        // en la fila de orders → el operador manual sabrá a qué dirección transferir.
+        // Si el usuario nunca conectó wallet, `extras` queda undefined y el backend
+        // crea la orden sin user_wallet_id; la wallet se añadirá luego en /order/:id.
+        // En venta no aplica: el IBAN no se recoge aquí, sino en el step 1 de /order/sell/:id.
+        let extras: { wallet_address?: string; wallet_network?: string } | undefined;
+        if (!isSellFlow && typeof window !== 'undefined') {
+          try {
+            const raw = localStorage.getItem(WALLET_ADDRESS_STORAGE_KEY) || '';
+            if (raw) {
+              const parsed = JSON.parse(raw);
+              // Requerimos address Y network: sin ambos no podemos upsertar (FK única).
+              if (parsed?.address && parsed?.network) {
+                extras = { wallet_address: parsed.address, wallet_network: parsed.network };
+              }
+            }
+          } catch { /* JSON corrupto en localStorage: no adjuntamos extras y seguimos */ }
+        }
+        // Firma de createOrder: (quoteId, type, amounts?, extras?).
+        //   - amounts: sólo se mandan en venta; en compra se infieren del quote.
+        //   - extras:  wallet_* en compra, iban/bank_account_id en venta (aquí no aplica).
         const response = await apiService.createOrder(
           quoteId,
           orderType,
@@ -779,7 +801,8 @@ const handleContinue = async () => {
                 amount_eur: amountEur,
                 amount_crypto: amountCrypto,
               }
-            : undefined
+            : undefined,
+          extras
         ) as { order_id?: string; orderId?: string; id?: string; [key: string]: unknown };
         orderId = response?.order_id ?? response?.orderId ?? response?.id ?? null;
         if (orderId) console.log('✅ Order created:', response);
@@ -864,8 +887,20 @@ const closeWalletDialog = () => {
   walletDialogError.value = '';
 };
 
-const saveWalletAddress = () => {
+// Guarda la wallet del usuario (destino para el flujo de compra).
+// Doble persistencia intencional:
+//   - localStorage: siempre, para que el simulador recuerde la última wallet sin
+//     depender del backend (ej. visitante anónimo que aún no se ha registrado).
+//   - backend /users/me/wallets: sólo si hay network seleccionada y hay sesión;
+//     este es el único sitio donde queda ligado al user_id, imprescindible para
+//     que el operador sepa a qué dirección transferir en una buy order.
+// Si el backend falla (401 / red), no bloqueamos el diálogo: el usuario ya tiene
+// la wallet en localStorage y su primera compra persistirá el upsert desde el
+// propio createOrder (ver bloque `extras` más abajo).
+const saveWalletAddress = async () => {
   const address = walletAddressInput.value?.trim() || '';
+  const network = walletNetworkInput.value || '';
+  const name = walletNameInput.value?.trim() || '';
   if (!address) {
     walletDialogError.value = 'Introduce una dirección de wallet';
     return;
@@ -875,12 +910,18 @@ const saveWalletAddress = () => {
     return;
   }
   if (typeof window !== 'undefined') {
-    const data = {
-      address,
-      network: walletNetworkInput.value || '',
-      name: walletNameInput.value?.trim() || '',
-    };
-    localStorage.setItem(WALLET_ADDRESS_STORAGE_KEY, JSON.stringify(data));
+    localStorage.setItem(
+      WALLET_ADDRESS_STORAGE_KEY,
+      JSON.stringify({ address, network, name })
+    );
+  }
+  // Requerimos network para upsert: la clave única de user_wallets es (user_id, address, network).
+  if (network) {
+    try {
+      await apiService.saveUserWallet(address, network, name || undefined);
+    } catch (err) {
+      console.warn('No se pudo persistir la wallet en el backend', err);
+    }
   }
   closeWalletDialog();
   walletSaveSuccess.value = true;

--- a/src/components/PriceSimulatorInline.vue
+++ b/src/components/PriceSimulatorInline.vue
@@ -900,7 +900,9 @@ const closeWalletDialog = () => {
 const saveWalletAddress = async () => {
   const address = walletAddressInput.value?.trim() || '';
   const network = walletNetworkInput.value || '';
-  const name = walletNameInput.value?.trim() || '';
+  // `undefined` cuando no hay nombre: JSON.stringify lo omite del objeto persistido
+  // y el backend recibe el parámetro opcional sin tener que evaluar truthy/falsy.
+  const name = walletNameInput.value?.trim() || undefined;
   if (!address) {
     walletDialogError.value = 'Introduce una dirección de wallet';
     return;
@@ -918,7 +920,7 @@ const saveWalletAddress = async () => {
   // Requerimos network para upsert: la clave única de user_wallets es (user_id, address, network).
   if (network) {
     try {
-      await apiService.saveUserWallet(address, network, name || undefined);
+      await apiService.saveUserWallet(address, network, name);
     } catch (err) {
       console.warn('No se pudo persistir la wallet en el backend', err);
     }

--- a/src/pages/order/[id].vue
+++ b/src/pages/order/[id].vue
@@ -653,7 +653,7 @@ const fetchOrder = async () => {
   error.value = null;
   isFallbackOrder.value = false;
   try {
-    const data = await apiService.getOrder(orderId.value);
+    const data = await apiService.getOrder(orderId.value, 'buy');
     order.value = data as Record<string, unknown>;
   } catch (e: any) {
     error.value = e?.message || 'No se pudo cargar la orden.';

--- a/src/pages/order/sell/[id].vue
+++ b/src/pages/order/sell/[id].vue
@@ -34,18 +34,20 @@ meta:
             Reintentar conexión
           </v-btn>
         </v-alert>
-        <h1 class="order-title">Tu orden de venta</h1>
-        <p class="order-subtitle">Completa los pasos para recibir EUR en tu cuenta bancaria</p>
 
+        <h1 class="order-title">Tu orden de venta</h1>
+        <p class="order-subtitle">Sigue los pasos para recibir EUR en tu cuenta bancaria</p>
+
+        <!-- Progress stepper: 1 Cuenta bancaria → 2 Depósito (envío de crypto) → 3 Estado -->
         <nav class="progress-stepper" aria-label="Progreso">
-          <div class="stepper-item" :class="{ done: bankFormDone, current: !bankFormDone }">
+          <div class="stepper-item" :class="{ done: bankSaved, current: !bankSaved }">
             <span class="stepper-num">1</span>
             <span class="stepper-label">Cuenta bancaria</span>
           </div>
-          <div class="stepper-line" :class="{ done: bankFormDone }" />
-          <div class="stepper-item" :class="{ done: declarationDone, current: bankFormDone && !declarationDone }">
+          <div class="stepper-line" :class="{ done: bankSaved }" />
+          <div class="stepper-item" :class="{ done: declarationDone, current: bankSaved && !declarationDone }">
             <span class="stepper-num">2</span>
-            <span class="stepper-label">Depósito USDC</span>
+            <span class="stepper-label">Depósito {{ assetSymbol }}</span>
           </div>
           <div class="stepper-line" :class="{ done: declarationDone }" />
           <div class="stepper-item" :class="{ current: declarationDone }">
@@ -54,65 +56,128 @@ meta:
           </div>
         </nav>
 
-        <section class="order-section">
+        <!-- Step 1: Bank account (form or saved state) -->
+        <section class="order-section bank-section" :class="{ completed: bankSaved }">
           <h2 class="section-title">
-            <span class="step-badge" :class="{ done: bankFormDone }">1</span>
-            Datos bancarios
+            <span class="step-badge" :class="{ done: bankSaved }">
+              <v-icon v-if="bankSaved" size="18" color="white">mdi-check</v-icon>
+              <span v-else>1</span>
+            </span>
+            Cuenta bancaria
           </h2>
-          <p class="section-desc">Usaremos estos datos para enviarte los EUR tras confirmar tu depósito USDC.</p>
+          <p class="section-desc">Indica el IBAN, titular y banco donde quieres recibir tus EUR.</p>
 
-          <div class="form-grid">
-            <v-text-field
-              v-model="bankIban"
-              label="IBAN"
-              placeholder="ES00 0000 0000 0000 0000 0000"
-              variant="outlined"
-              density="comfortable"
-              hide-details="auto"
-              :error-messages="ibanError"
-              @blur="validateIban"
-            />
-            <v-text-field
-              v-model="bankHolderName"
-              label="Nombre del titular"
-              placeholder="Nombre y apellidos"
-              variant="outlined"
-              density="comfortable"
-              hide-details="auto"
-            />
-            <v-text-field
-              v-model="bankName"
-              label="Nombre del banco"
-              placeholder="Ej. Banco Santander"
-              variant="outlined"
-              density="comfortable"
-              hide-details="auto"
-            />
+          <!-- Saved bank: show confirmation + option to change -->
+          <div v-if="bankSaved" class="bank-saved">
+            <div class="bank-saved-grid">
+              <div class="bank-saved-row">
+                <span class="bank-saved-label">IBAN</span>
+                <span class="bank-saved-value bank-saved-mono">{{ formattedIban }}</span>
+              </div>
+              <div class="bank-saved-row">
+                <span class="bank-saved-label">Titular</span>
+                <span class="bank-saved-value">{{ savedBankHolderName }}</span>
+              </div>
+              <div class="bank-saved-row">
+                <span class="bank-saved-label">Banco</span>
+                <span class="bank-saved-value">{{ savedBankName }}</span>
+              </div>
+            </div>
+            <div class="bank-saved-actions">
+              <v-icon color="#1cba75" size="20">mdi-check-circle</v-icon>
+              <span class="bank-saved-ok">Datos guardados</span>
+              <v-btn variant="text" size="small" color="primary" @click="clearBankSaved">
+                Cambiar
+              </v-btn>
+            </div>
           </div>
+
+          <!-- Bank form -->
+          <template v-else>
+            <div v-if="savedBankAccounts.length" class="saved-accounts-hint">
+              <v-icon size="18" color="primary">mdi-bank-check</v-icon>
+              <span>
+                Tienes {{ savedBankAccounts.length }}
+                {{ savedBankAccounts.length === 1 ? 'cuenta guardada' : 'cuentas guardadas' }}.
+                Vuelve a escribir el IBAN para confirmar la que quieras usar.
+              </span>
+            </div>
+            <div class="form-grid">
+              <v-text-field
+                v-model="bankIban"
+                label="IBAN"
+                placeholder="ES00 0000 0000 0000 0000 0000"
+                variant="outlined"
+                density="comfortable"
+                hide-details="auto"
+                :error-messages="ibanError"
+                @blur="validateIban"
+              />
+              <v-text-field
+                v-model="bankHolderName"
+                label="Nombre del titular"
+                placeholder="Nombre y apellidos"
+                variant="outlined"
+                density="comfortable"
+                hide-details="auto"
+              />
+              <v-text-field
+                v-model="bankName"
+                label="Nombre del banco"
+                placeholder="Ej. Banco Santander"
+                variant="outlined"
+                density="comfortable"
+                hide-details="auto"
+              />
+              <v-btn
+                color="primary"
+                size="large"
+                :disabled="!canSaveBank"
+                :loading="savingBank"
+                class="save-bank-btn"
+                @click="saveBank"
+              >
+                Verificar y guardar cuenta
+              </v-btn>
+            </div>
+            <p class="bank-hint">Verificamos formato del IBAN antes de guardar. Tus datos quedan asociados a esta orden.</p>
+          </template>
         </section>
 
+        <!-- Step 2: Crypto deposit instructions -->
         <section class="order-section">
           <h2 class="section-title">
             <span class="step-badge" :class="{ done: declarationDone }">2</span>
-            Instrucciones de depósito USDC
+            Instrucciones de depósito {{ assetSymbol }}
           </h2>
           <p class="section-desc">Envía exactamente el monto indicado desde una wallet de tu propiedad.</p>
 
           <div class="sell-cards">
             <div class="sell-card">
               <span class="sell-card-label">Monto a enviar</span>
-              <strong class="sell-card-value">{{ cryptoAmount }} {{ order.asset || 'USDC' }}</strong>
+              <strong class="sell-card-value">{{ cryptoAmount }} {{ assetSymbol }}</strong>
             </div>
 
             <div class="sell-card">
               <span class="sell-card-label">Red de depósito</span>
-              <v-chip-group v-model="selectedNetwork" mandatory class="network-group">
-                <v-chip value="polygon" class="network-chip" variant="outlined">Polygon</v-chip>
-                <v-chip value="base" class="network-chip" variant="outlined">Base</v-chip>
+              <v-chip-group v-if="hasDepositWallets" v-model="selectedNetwork" mandatory class="network-group">
+                <v-chip
+                  v-for="net in availableNetworks"
+                  :key="net.value"
+                  :value="net.value"
+                  class="network-chip"
+                  variant="outlined"
+                >
+                  {{ net.label }}
+                </v-chip>
               </v-chip-group>
+              <v-alert v-else type="warning" density="compact" variant="tonal" class="mt-2">
+                No se pudieron cargar las direcciones de depósito. Recarga la
+                página en unos segundos o contacta a soporte.
+              </v-alert>
             </div>
 
-            <div class="sell-card">
+            <div v-if="hasDepositWallets" class="sell-card">
               <span class="sell-card-label">Wallet de Exury (destino)</span>
               <div class="wallet-row">
                 <span class="wallet-address">{{ exuryWalletAddress }}</span>
@@ -128,8 +193,8 @@ meta:
             <h3 class="origin-title">Declaración de origen</h3>
             <v-text-field
               v-model="sourceWallet"
-              label="Wallet desde donde enviarás USDC"
-              placeholder="0x..."
+              label="Wallet desde donde enviarás los fondos"
+              placeholder="Tu dirección de origen"
               variant="outlined"
               density="comfortable"
               hide-details="auto"
@@ -143,8 +208,37 @@ meta:
               label="Garantizo que la wallet es de mi propiedad"
             />
           </div>
+
+          <!-- CTA final: dispara el payout SEPA una vez el usuario ha enviado
+               los fondos. Se habilita sólo cuando banco + declaración están OK. -->
+          <div class="confirm-sale-box">
+            <div class="confirm-sale-copy">
+              <strong>¿Ya enviaste tus {{ assetSymbol }}?</strong>
+              <p>
+                Tras verificar tu depósito en la wallet de Exury iniciaremos la
+                transferencia SEPA a tu IBAN. Este paso es definitivo.
+              </p>
+            </div>
+            <v-btn
+              color="primary"
+              size="large"
+              :disabled="!canConfirmSale"
+              :loading="confirmingSale"
+              class="confirm-sale-btn"
+              @click="confirmSale"
+            >
+              <template v-if="saleConfirmed">
+                <v-icon start size="18">mdi-check-circle</v-icon>
+                Venta confirmada
+              </template>
+              <template v-else>
+                He enviado los fondos
+              </template>
+            </v-btn>
+          </div>
         </section>
 
+        <!-- Step 3: Status timeline -->
         <section ref="statusSectionRef" class="order-section status-section">
           <h2 class="section-title">Estado de la orden</h2>
           <p class="section-desc">Seguimiento de tu orden de venta, desde el envío hasta la acreditación en cuenta.</p>
@@ -172,7 +266,7 @@ meta:
 
         <div class="order-summary">
           <span class="order-id">Orden {{ orderId }}</span>
-          <span class="order-amount">{{ cryptoAmount }} {{ order.asset || 'USDC' }} → {{ fiatAmount }} EUR</span>
+          <span class="order-amount">{{ cryptoAmount }} {{ assetSymbol }} → {{ fiatAmount }} EUR</span>
         </div>
       </template>
     </div>
@@ -201,30 +295,73 @@ const loading = ref(true);
 const error = ref<string | null>(null);
 const order = ref<Record<string, unknown> | null>(null);
 
+// --- Bank form state ---
 const bankIban = ref('');
 const bankHolderName = ref('');
 const bankName = ref('');
+const savedBankHolderName = ref('');
+const savedBankName = ref('');
+const bankSaved = ref(false);
+const savingBank = ref(false);
+const ibanError = ref('');
+
+// --- Origin wallet ---
 const sourceWallet = ref('');
 const walletOwnershipConfirmed = ref(false);
-const selectedNetwork = ref<'polygon' | 'base'>('polygon');
-
-const snackbar = ref({ show: false, text: '', color: 'success' });
-
-const env = import.meta.env as Record<string, string | undefined>;
-const polygonWallet = (env.VITE_EXURY_USDC_WALLET_POLYGON ?? '').trim();
-const baseWallet = (env.VITE_EXURY_USDC_WALLET_BASE ?? '').trim();
-
-const exuryWalletAddress = computed(() => {
-  if (selectedNetwork.value === 'polygon') {
-    return polygonWallet || '0xA5f3b9C2D14E6f7A88A0cD12B44Ef58A9152C7D1';
-  }
-  return baseWallet || '0x6D4c0A1eF53d7B2A49E1D1a3A653fC0b3d90Ce72';
-});
-
-const ibanError = ref('');
 const sourceWalletError = ref('');
 
+// --- Network selection ---
+const selectedNetwork = ref<string>('');
+
+const snackbar = ref({ show: false, text: '', color: 'primary' });
+
+// --- Wallets de Exury por activo y red ---
+// Las direcciones ya NO viven en el código del frontend. Fuentes soportadas
+// (por orden de prioridad):
+//   1. GET /v1/deposit-wallets  → backend lee EXURY_DEPOSIT_WALLETS_JSON.
+//   2. VITE_EXURY_DEPOSIT_WALLETS_JSON (opcional, para dev local sin backend).
+// Si ninguna devuelve datos, la sección de "Red de depósito" muestra un aviso
+// y el botón de confirmación queda bloqueado hasta que haya direcciones.
+type NetworkOption = { value: string; label: string; address: string };
+
+const parseEnvWallets = (): Record<string, NetworkOption[]> => {
+  const raw = import.meta.env.VITE_EXURY_DEPOSIT_WALLETS_JSON as string | undefined;
+  if (!raw) return {};
+  try {
+    const parsed = JSON.parse(raw);
+    return parsed && typeof parsed === 'object' ? parsed : {};
+  } catch {
+    return {};
+  }
+};
+const depositWallets = ref<Record<string, NetworkOption[]>>(parseEnvWallets());
+
+const assetSymbol = computed(() => {
+  const a = String(order.value?.asset || 'USDC').toUpperCase();
+  return depositWallets.value[a] ? a : 'USDC';
+});
+
+const availableNetworks = computed<NetworkOption[]>(() => {
+  return depositWallets.value[assetSymbol.value] || depositWallets.value.USDC || [];
+});
+
+// --- Bank accounts guardadas (persistidas en backend) ---
+type SavedBankAccount = { id: string; bank_name: string | null; created_at: string };
+const savedBankAccounts = ref<SavedBankAccount[]>([]);
+
+const exuryWalletAddress = computed(() => {
+  const list = availableNetworks.value;
+  const match = list.find((n) => n.value === selectedNetwork.value);
+  return match?.address || list[0]?.address || '—';
+});
+
+// --- IBAN helpers ---
 const normalizeIban = (value: string) => value.replace(/\s+/g, '').toUpperCase();
+
+const formattedIban = computed(() => {
+  const n = normalizeIban(bankIban.value);
+  return n.replace(/(.{4})/g, '$1 ').trim();
+});
 
 const validateIban = () => {
   const normalized = normalizeIban(bankIban.value);
@@ -244,14 +381,134 @@ const validateSourceWallet = () => {
   sourceWalletError.value = value.length >= 26 ? '' : 'La wallet debe tener al menos 26 caracteres';
 };
 
-const bankFormDone = computed(() => {
-  return !!normalizeIban(bankIban.value) && !!bankHolderName.value.trim() && !!bankName.value.trim() && !ibanError.value;
+// --- Bank save flow ---
+const canSaveBank = computed(() => {
+  const ibanOk = !!normalizeIban(bankIban.value) && /^[A-Z]{2}\d{13,32}$/.test(normalizeIban(bankIban.value));
+  return ibanOk && !!bankHolderName.value.trim() && !!bankName.value.trim();
 });
 
 const declarationDone = computed(() => {
-  return bankFormDone.value && !!sourceWallet.value.trim() && !sourceWalletError.value && walletOwnershipConfirmed.value;
+  return bankSaved.value && !!sourceWallet.value.trim() && !sourceWalletError.value && walletOwnershipConfirmed.value;
 });
 
+// Click del botón "Verificar y guardar cuenta".
+// Flujo: valida IBAN → POST /users/me/bank-accounts (backend calcula SHA256 y
+// upsertea por user_id+iban_hash) → refresca la lista de cuentas guardadas.
+// Si el backend falla o no hay sesión, no bloqueamos la venta: guardamos los datos
+// sólo en el estado local de la página y avisamos con un snackbar tipo warning,
+// para que el usuario pueda continuar con esta orden aunque sea "anónima en DB".
+const saveBank = async () => {
+  validateIban();
+  if (!canSaveBank.value || ibanError.value) return;
+  savingBank.value = true;
+  const normalized = normalizeIban(bankIban.value);
+  try {
+    // Backend sólo conoce hash(iban) + bank_name; el holder_name vive en la UI.
+    await apiService.saveBankAccount(normalized, bankName.value.trim());
+    savedBankHolderName.value = bankHolderName.value.trim();
+    savedBankName.value = bankName.value.trim();
+    bankSaved.value = true;
+    showSnackbar('Cuenta bancaria verificada y guardada', 'success');
+    // Rehidratamos para reflejar el +1 en "cuentas guardadas" si el user vuelve a vender.
+    await loadSavedBankAccounts();
+  } catch (err: any) {
+    // Fallback local: mantenemos la experiencia del usuario aunque el backend caiga.
+    // El IBAN igualmente viajará en el request del payout, así que la venta puede
+    // completarse; simplemente no queda huella "verificada" en bank_accounts.
+    savedBankHolderName.value = bankHolderName.value.trim();
+    savedBankName.value = bankName.value.trim();
+    bankSaved.value = true;
+    const msg = err?.status === 401
+      ? 'Sesión requerida para guardar en tu cuenta; los datos valen sólo para esta orden.'
+      : 'No se pudo guardar en el servidor; los datos valen sólo para esta orden.';
+    showSnackbar(msg, 'warning');
+  } finally {
+    savingBank.value = false;
+  }
+};
+
+// Trae las cuentas del usuario para mostrar el hint "Tienes N cuentas guardadas".
+// Silencia errores (401 en visitante, backend caído): la página sigue funcional
+// con el formulario "en blanco" como si no tuviera cuentas previas.
+const loadSavedBankAccounts = async () => {
+  try {
+    const res = await apiService.getBankAccounts();
+    savedBankAccounts.value = res?.accounts || [];
+  } catch {
+    savedBankAccounts.value = [];
+  }
+};
+
+// Hidrata las wallets de Exury desde el backend (que las lee de EXURY_DEPOSIT_WALLETS_JSON).
+// Si el backend no responde, mantenemos lo que venga de VITE_EXURY_DEPOSIT_WALLETS_JSON
+// (puede ser vacío). La UI gestiona el caso "sin direcciones" con un aviso visible.
+const loadDepositWallets = async () => {
+  try {
+    const res = await apiService.getDepositWallets();
+    if (res?.wallets && Object.keys(res.wallets).length > 0) {
+      depositWallets.value = res.wallets;
+    }
+  } catch {
+    // Silencioso: la UI detectará que depositWallets está vacío y mostrará el aviso.
+  }
+};
+
+// Flag para el template: si no tenemos direcciones de ningún origen, avisamos
+// y bloqueamos la confirmación de venta (no queremos que el usuario envíe a "nada").
+const hasDepositWallets = computed(() => availableNetworks.value.length > 0);
+
+const clearBankSaved = () => {
+  bankSaved.value = false;
+  savedBankHolderName.value = '';
+  savedBankName.value = '';
+  ibanError.value = '';
+};
+
+// --- Confirmar venta y disparar payout SEPA ---
+// Se llama cuando el usuario pulsa "He enviado los fondos" tras completar
+// banco + declaración de origen. Llama a POST /orders/:id/sell/payout que en
+// el backend:
+//   1) Registra/confirma la cuenta bancaria (hash) del usuario.
+//   2) Persiste orders.iban si no estaba guardado.
+//   3) Ejecuta la venta en Binance y abre la retirada SEPA vía PayDo.
+// En dev (NODE_ENV=development) tanto Binance como PayDo están mockeados, así
+// que la respuesta es inmediata y la orden pasa a status 'processing' → la
+// timeline avanza sola porque statusStep es computed sobre order.status.
+const confirmingSale = ref(false);
+const saleConfirmed = ref(false);
+const canConfirmSale = computed(
+  () =>
+    declarationDone.value &&
+    !confirmingSale.value &&
+    !saleConfirmed.value &&
+    hasDepositWallets.value
+);
+
+const confirmSale = async () => {
+  if (!canConfirmSale.value) return;
+  if (isTempOrder.value) {
+    // Sin orden real en backend no podemos disparar payout; avisamos y salimos.
+    showSnackbar('La orden aún no se confirmó con el backend. Reintenta la conexión.', 'warning');
+    return;
+  }
+  confirmingSale.value = true;
+  try {
+    await apiService.initiateSellPayout(orderId.value, normalizeIban(bankIban.value));
+    saleConfirmed.value = true;
+    showSnackbar('Venta confirmada. Procesando retirada SEPA…', 'success');
+    // Refrescamos la orden para que el tracker avance a "Verificación/Fondos en camino".
+    await fetchOrder();
+  } catch (err: any) {
+    const msg = err?.status === 401
+      ? 'Sesión requerida para confirmar la venta.'
+      : err?.response?.error || 'No se pudo iniciar la retirada. Vuelve a intentarlo en unos segundos.';
+    showSnackbar(msg, 'warning');
+  } finally {
+    confirmingSale.value = false;
+  }
+};
+
+// --- Display amounts ---
 const cryptoAmount = computed(() => {
   const rawAmount = order.value?.amount_crypto ?? order.value?.crypto_amount ?? 0;
   return String(rawAmount);
@@ -261,21 +518,23 @@ const fiatAmount = computed(() => {
   return new Intl.NumberFormat('es-ES', { minimumFractionDigits: 2, maximumFractionDigits: 2 }).format(value);
 });
 
+// --- Status timeline ---
 const statusStep = computed(() => {
   const s = String(order.value?.status ?? order.value?.payment_status ?? 'pending').toLowerCase();
   if (s === 'completed' || s === 'funds_in_account' || s === 'delivered') return 4;
-  if (s === 'funds_in_transit' || s === 'sent' || s === 'processing') return 3;
+  if (s === 'funds_in_transit' || s === 'sent' || s === 'processing' || s === 'payment_pending') return 3;
   if (s === 'received' || s === 'verifying' || s === 'confirmed') return 2;
   return 1;
 });
 
 const statusSteps = [
-  { step: 1, title: 'Envío de fondos', desc: 'Esperando tu depósito USDC en la wallet de Exury.' },
+  { step: 1, title: 'Envío de fondos', desc: 'Esperando tu depósito en la wallet de Exury.' },
   { step: 2, title: 'Verificación', desc: 'Verificamos red, origen de fondos y titularidad de wallet.' },
   { step: 3, title: 'Fondos en camino', desc: 'Transferencia EUR iniciada a tu cuenta bancaria.' },
   { step: 4, title: 'Fondos en cuenta', desc: 'Pago acreditado correctamente en tu cuenta bancaria.' },
 ];
 
+// --- Persistencia local de la orden de venta ---
 const loadSellOrderData = () => {
   if (typeof window === 'undefined') return;
   const storageKey = `exury_sell_order_data_${orderId.value}`;
@@ -286,33 +545,48 @@ const loadSellOrderData = () => {
       bankIban?: string;
       bankHolderName?: string;
       bankName?: string;
+      bankSaved?: boolean;
       sourceWallet?: string;
       walletOwnershipConfirmed?: boolean;
-      selectedNetwork?: 'polygon' | 'base';
+      selectedNetwork?: string;
     };
     bankIban.value = saved.bankIban ?? '';
     bankHolderName.value = saved.bankHolderName ?? '';
     bankName.value = saved.bankName ?? '';
+    bankSaved.value = !!saved.bankSaved;
+    if (bankSaved.value) {
+      savedBankHolderName.value = bankHolderName.value.trim();
+      savedBankName.value = bankName.value.trim();
+    }
     sourceWallet.value = saved.sourceWallet ?? '';
     walletOwnershipConfirmed.value = saved.walletOwnershipConfirmed ?? false;
-    selectedNetwork.value = saved.selectedNetwork ?? 'polygon';
+    if (saved.selectedNetwork) selectedNetwork.value = saved.selectedNetwork;
   } catch {
     /* ignore corrupted local state */
   }
 };
 
-watch([bankIban, bankHolderName, bankName, sourceWallet, walletOwnershipConfirmed, selectedNetwork], () => {
+watch([bankIban, bankHolderName, bankName, bankSaved, sourceWallet, walletOwnershipConfirmed, selectedNetwork], () => {
   if (typeof window === 'undefined' || !orderId.value) return;
   const storageKey = `exury_sell_order_data_${orderId.value}`;
   localStorage.setItem(storageKey, JSON.stringify({
     bankIban: bankIban.value,
     bankHolderName: bankHolderName.value,
     bankName: bankName.value,
+    bankSaved: bankSaved.value,
     sourceWallet: sourceWallet.value,
     walletOwnershipConfirmed: walletOwnershipConfirmed.value,
     selectedNetwork: selectedNetwork.value,
   }));
 }, { deep: true });
+
+// Si cambia el activo, asegurar que la red seleccionada exista para él
+watch(assetSymbol, () => {
+  const list = availableNetworks.value;
+  if (!list.find((n) => n.value === selectedNetwork.value)) {
+    selectedNetwork.value = list[0]?.value || '';
+  }
+}, { immediate: true });
 
 const fetchOrder = async () => {
   if (!orderId.value) return;
@@ -341,7 +615,7 @@ const fetchOrder = async () => {
       }
       return;
     }
-    const data = await apiService.getOrder(orderId.value);
+    const data = await apiService.getOrder(orderId.value, 'sell');
     isFallbackOrder.value = false;
     order.value = data as Record<string, unknown>;
   } catch (e: unknown) {
@@ -379,24 +653,33 @@ const tryRecoverOrder = async () => {
   }
 };
 
-const showSnackbar = (text: string, color: 'success' | 'primary' = 'primary') => {
+const showSnackbar = (text: string, color: 'success' | 'primary' | 'warning' = 'primary') => {
   snackbar.value = { show: true, text, color };
 };
 
 const copyWallet = async () => {
   try {
     await navigator.clipboard.writeText(exuryWalletAddress.value);
-    showSnackbar('Wallet copiada al portapapeles');
+    showSnackbar('Wallet copiada al portapapeles', 'success');
   } catch {
-    showSnackbar('No se pudo copiar la wallet', 'success');
+    showSnackbar('No se pudo copiar la wallet', 'primary');
   }
 };
 
 const statusSectionRef = ref<HTMLElement | null>(null);
 
+// Montaje de la página de venta. Orden intencional:
+//  1. fetchOrder(): necesitamos la orden primero para decidir asset/monto/estado.
+//  2. loadSellOrderData(): restaura campos que el usuario haya llenado antes y recargado.
+//  3. loadDepositWallets / loadSavedBankAccounts: en paralelo (no await) porque son
+//     "nice to have"; la página ya es usable sin ellos gracias al fallback local.
+//  4. Sólo si estamos en una orden temporal (fallback tras fallo del backend al crear),
+//     programamos un reintento pasados 2s para intentar recuperar la orden real.
 onMounted(async () => {
   await fetchOrder();
   loadSellOrderData();
+  loadDepositWallets();
+  loadSavedBankAccounts();
   if (isTempOrder.value) {
     recoveryTimer = setTimeout(() => {
       tryRecoverOrder();
@@ -451,14 +734,13 @@ onBeforeUnmount(() => {
 .order-title { font-size: clamp(24px, 4vw, 32px); color: #fff; margin: 0; }
 .order-subtitle { font-size: 16px; color: rgba(255, 255, 255, 0.72); margin: 0; }
 
+/* Stepper */
 .progress-stepper {
   display: flex;
   align-items: center;
   padding: 10px 0;
 }
-
 .stepper-item { display: flex; flex-direction: column; align-items: center; gap: 4px; }
-
 .stepper-num {
   width: 28px;
   height: 28px;
@@ -471,32 +753,28 @@ onBeforeUnmount(() => {
   font-size: 13px;
   font-weight: 700;
 }
-
 .stepper-item.current .stepper-num,
 .stepper-item.done .stepper-num { background: #1cba75; color: #fff; }
-
 .stepper-label {
   font-size: 11px;
   text-transform: uppercase;
   color: rgba(255, 255, 255, 0.6);
   letter-spacing: 0.03em;
 }
-
 .stepper-line {
   width: 24px;
   height: 2px;
   background: rgba(255, 255, 255, 0.2);
 }
-
 .stepper-line.done { background: #1cba75; }
 
+/* Sections */
 .order-section {
   background: rgba(255, 255, 255, 0.05);
   border: 1px solid rgba(255, 255, 255, 0.1);
   border-radius: 16px;
   padding: 24px;
 }
-
 .section-title {
   display: flex;
   align-items: center;
@@ -505,7 +783,6 @@ onBeforeUnmount(() => {
   font-size: 18px;
   margin: 0 0 8px 0;
 }
-
 .section-desc { color: rgba(255, 255, 255, 0.72); margin: 0 0 16px 0; font-size: 14px; }
 
 .step-badge {
@@ -519,18 +796,82 @@ onBeforeUnmount(() => {
   justify-content: center;
   font-size: 14px;
 }
+.step-badge.done { background: #1cba75; }
 
+/* Bank form / saved card */
 .form-grid { display: grid; grid-template-columns: 1fr; gap: 12px; }
+.save-bank-btn { text-transform: none; font-weight: 600; }
+.saved-accounts-hint {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin: 0 0 12px 0;
+  padding: 8px 12px;
+  border-radius: 8px;
+  background: rgba(27, 143, 255, 0.08);
+  border: 1px solid rgba(27, 143, 255, 0.2);
+  font-size: 13px;
+  color: rgba(255, 255, 255, 0.85);
+}
+.bank-hint {
+  font-size: 12px;
+  color: rgba(255, 255, 255, 0.5);
+  margin: 12px 0 0 0;
+}
 
+.bank-saved { margin-top: 8px; }
+
+.bank-saved-grid {
+  padding: 16px;
+  background: rgba(28, 202, 117, 0.08);
+  border: 1px solid rgba(28, 202, 117, 0.25);
+  border-radius: 12px;
+  margin-bottom: 12px;
+}
+.bank-saved-row {
+  display: flex;
+  align-items: flex-start;
+  gap: 12px;
+  padding: 8px 0;
+}
+.bank-saved-row:not(:last-child) {
+  border-bottom: 1px solid rgba(255, 255, 255, 0.08);
+}
+.bank-saved-label {
+  flex: 0 0 120px;
+  font-size: 12px;
+  color: rgba(255, 255, 255, 0.6);
+  text-transform: uppercase;
+  letter-spacing: 0.03em;
+}
+.bank-saved-value {
+  flex: 1;
+  font-size: 14px;
+  color: rgba(255, 255, 255, 0.95);
+  word-break: break-all;
+}
+.bank-saved-mono {
+  font-family: ui-monospace, monospace;
+}
+.bank-saved-actions {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+.bank-saved-ok {
+  flex: 1;
+  font-size: 13px;
+  color: #1cba75;
+}
+
+/* Sell deposit cards */
 .sell-cards { display: flex; flex-direction: column; gap: 12px; margin-bottom: 16px; }
-
 .sell-card {
   padding: 14px;
   border-radius: 12px;
   background: rgba(255, 255, 255, 0.04);
   border: 1px solid rgba(255, 255, 255, 0.08);
 }
-
 .sell-card-label {
   display: block;
   font-size: 12px;
@@ -539,9 +880,8 @@ onBeforeUnmount(() => {
   color: rgba(255, 255, 255, 0.6);
   margin-bottom: 8px;
 }
-
 .sell-card-value { color: #fff; font-size: 18px; }
-.network-group { gap: 8px; }
+.network-group { gap: 8px; flex-wrap: wrap; }
 .network-chip { text-transform: none; font-weight: 600; }
 
 .wallet-row {
@@ -550,7 +890,6 @@ onBeforeUnmount(() => {
   align-items: center;
   flex-wrap: wrap;
 }
-
 .wallet-address {
   font-family: ui-monospace, monospace;
   color: #fff;
@@ -564,24 +903,37 @@ onBeforeUnmount(() => {
   border-radius: 12px;
   border: 1px solid rgba(28, 202, 117, 0.25);
   background: rgba(28, 202, 117, 0.06);
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
 }
+.origin-title { margin: 0 0 4px 0; font-size: 15px; color: #fff; }
 
-.origin-title { margin: 0 0 10px 0; font-size: 15px; color: #fff; }
+.confirm-sale-box {
+  margin-top: 16px;
+  padding: 16px;
+  border-radius: 12px;
+  border: 1px solid rgba(27, 143, 255, 0.25);
+  background: rgba(27, 143, 255, 0.06);
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+.confirm-sale-copy strong { display: block; color: #fff; font-size: 15px; }
+.confirm-sale-copy p { margin: 4px 0 0 0; color: rgba(255, 255, 255, 0.7); font-size: 13px; line-height: 1.5; }
+.confirm-sale-btn { align-self: flex-start; text-transform: none; font-weight: 600; }
 
+/* Status timeline */
 .status-timeline { display: flex; flex-direction: column; }
-
 .status-step {
   display: flex;
   gap: 0;
   padding: 12px 0;
   opacity: 0.55;
 }
-
 .status-step.active { opacity: 1; }
 .status-step.done { opacity: 0.85; }
-
 .status-left { display: flex; flex-direction: column; align-items: center; flex-shrink: 0; }
-
 .status-dot {
   width: 36px;
   height: 36px;
@@ -593,24 +945,20 @@ onBeforeUnmount(() => {
   justify-content: center;
   font-weight: 700;
 }
-
 .status-step.active .status-dot,
 .status-step.done .status-dot { background: #1cba75; }
-
 .status-connector {
   width: 2px;
   min-height: 18px;
   background: rgba(255, 255, 255, 0.15);
   margin: 4px 0;
 }
-
 .status-content {
   padding-left: 14px;
   display: flex;
   flex-direction: column;
   gap: 4px;
 }
-
 .status-content strong { color: #fff; font-size: 15px; }
 .status-content p { margin: 0; color: rgba(255, 255, 255, 0.72); font-size: 13px; }
 

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -69,7 +69,7 @@ class ApiService {
 
     try {
       const response = await fetch(url, config);
-      
+
       if (!response.ok) {
         const error = await response.json().catch(() => ({ error: 'Unknown error' }));
         const errorMessage = error.error || error.message || `HTTP ${response.status}`;
@@ -79,8 +79,8 @@ class ApiService {
           fullError: error
         });
         const apiError = new Error(errorMessage);
-        (apiError as any).response = { 
-          status: response.status, 
+        (apiError as any).response = {
+          status: response.status,
           error: errorMessage,
           data: error
         };
@@ -125,17 +125,105 @@ class ApiService {
   }
 
   /**
-   * Create a new order
+   * Create a new order.
+   * `extras` permite pasar iban (sell) o wallet (buy) para que el backend los persista
+   * y los relacione con la orden vía bank_account_id / user_wallet_id.
    */
   async createOrder(
     quoteId: string,
     type: 'buy' | 'sell' = 'buy',
-    amounts?: { amount_eur?: number; amount_crypto?: number }
+    amounts?: { amount_eur?: number; amount_crypto?: number },
+    extras?: {
+      iban?: string;
+      bank_account_id?: string;
+      user_wallet_id?: string;
+      wallet_address?: string;
+      wallet_network?: string;
+    }
   ) {
     return this.request('/orders', {
       method: 'POST',
-      body: JSON.stringify({ quote_id: quoteId, type, ...amounts }),
+      body: JSON.stringify({ quote_id: quoteId, type, ...amounts, ...extras }),
     });
+  }
+
+  // Dispara la retirada SEPA para una sell order tras el depósito crypto.
+  // El IBAN viaja aquí en claro: el backend lo usa para PayDo y lo persiste
+  // en orders.iban (si no estaba) + upsert del hash en bank_accounts.
+  async initiateSellPayout(orderId: string, iban: string) {
+    return this.request<{
+      payment_id: string;
+      withdrawal_transaction_id: string;
+      crypto_transaction_id: string;
+      binance_order_id: string;
+    }>(`/orders/${orderId}/sell/payout`, {
+      method: 'POST',
+      body: JSON.stringify({ iban }),
+    });
+  }
+
+  // --- Bank accounts (sell flow) -----------------------------------------
+  // El backend sólo guarda hash(IBAN) + bank_name ligados al user_id autenticado.
+  // El IBAN en claro NO se almacena en bank_accounts; vive "per order" en orders.iban.
+  // Por eso getBankAccounts NUNCA devuelve el IBAN: sólo id, bank_name y created_at.
+
+  // Lista cuentas verificadas del usuario. Útil para mostrar "tienes N cuentas guardadas".
+  async getBankAccounts() {
+    return this.request<{ accounts: Array<{ id: string; bank_name: string | null; created_at: string }> }>(
+      '/users/me/bank-accounts'
+    );
+  }
+
+  // Verifica y registra el IBAN del usuario. El backend calcula SHA256 y hace upsert
+  // por (user_id, iban_hash); si la cuenta ya existía, sólo actualiza bank_name.
+  async saveBankAccount(iban: string, bankName?: string) {
+    return this.request<{ id: string; bank_name: string | null; created_at: string }>(
+      '/users/me/bank-accounts',
+      {
+        method: 'POST',
+        body: JSON.stringify({ iban, bank_name: bankName || null }),
+      }
+    );
+  }
+
+  async deleteBankAccount(id: string) {
+    return this.request<void>(`/users/me/bank-accounts/${id}`, { method: 'DELETE' });
+  }
+
+  // --- User wallets (buy flow) -------------------------------------------
+  // A diferencia del IBAN, la address on-chain es pública: se guarda en claro para
+  // poder ejecutar la transferencia al usuario cuando compra. Clave única por
+  // (user_id, address, network): el mismo 0x… en la misma red es una sola wallet,
+  // aunque reciba varios tokens (USDC, ETH, USDT…) — el asset lo lleva la orden.
+
+  async getUserWallets() {
+    return this.request<{ wallets: Array<{ id: string; address: string; network: string; name: string | null; created_at: string }> }>(
+      '/users/me/wallets'
+    );
+  }
+
+  async saveUserWallet(address: string, network: string, name?: string) {
+    return this.request<{ id: string; address: string; network: string; name: string | null; created_at: string }>(
+      '/users/me/wallets',
+      {
+        method: 'POST',
+        body: JSON.stringify({ address, network, name: name || null }),
+      }
+    );
+  }
+
+  async deleteUserWallet(id: string) {
+    return this.request<void>(`/users/me/wallets/${id}`, { method: 'DELETE' });
+  }
+
+  // --- Exury deposit wallets (public) ------------------------------------
+  // Endpoint público (sin JWT): devuelve las direcciones de recepción de Exury
+  // agrupadas por asset y red. La fuente real es la env var EXURY_DEPOSIT_WALLETS_JSON
+  // del backend; el fallback del frontend se usa sólo si el backend no responde.
+  async getDepositWallets() {
+    return this.request<{
+      wallets: Record<string, Array<{ value: string; label: string; address: string }>>;
+    }>('/deposit-wallets');
   }
 
   /**
@@ -146,10 +234,14 @@ class ApiService {
   }
 
   /**
-   * Get order details
+   * Get order details.
+   * Si se pasa `type`, usamos la ruta tipada (/orders/sell/:id o /orders/buy/:id)
+   * para que en Network/logs quede claro de qué flujo estamos hablando.
+   * Sin `type` cae en la ruta genérica /orders/:id (compat hacia atrás).
    */
-  async getOrder(orderId: string) {
-    return this.request(`/orders/${orderId}`);
+  async getOrder(orderId: string, type?: 'buy' | 'sell') {
+    const path = type ? `/orders/${type}/${orderId}` : `/orders/${orderId}`;
+    return this.request(path);
   }
 
   /**

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -1,7 +1,21 @@
 /// <reference types="vite/client" />
-
 declare module "*.vue" {
   import type { DefineComponent } from "vue";
   const component: DefineComponent<{}, {}, any>;
   export default component;
+}
+
+interface ImportMetaEnv {
+  readonly VITE_API_BASE_URL?: string;
+  readonly VITE_RAILWAY_API_URL?: string;
+  readonly VITE_BANK_BENEFICIARY?: string;
+  readonly VITE_BANK_IBAN?: string;
+  readonly VITE_BANK_NAME?: string;
+  // JSON stringificado con las wallets de Exury (fallback dev-only).
+  // En prod debe estar vacío; la fuente es EXURY_DEPOSIT_WALLETS_JSON en el backend.
+  readonly VITE_EXURY_DEPOSIT_WALLETS_JSON?: string;
+}
+
+interface ImportMeta {
+  readonly env: ImportMetaEnv;
 }


### PR DESCRIPTION
… endpoint tipado

- Nueva página /order/sell/:id con instrucciones de depósito, declaración de origen y CTA "He enviado los fondos" para disparar el payout SEPA.
- Persistencia opcional de IBAN (cuentas bancarias del usuario) y de wallet on-chain del usuario en localStorage + API; el front pasa wallet/IBAN como extras al crear la orden.
- Wallets de depósito de Exury removidas del código fuente: ahora se obtienen de GET /v1/deposit-wallets (env var del backend) con fallback opcional via VITE_EXURY_DEPOSIT_WALLETS_JSON para desarrollo.
- Llamadas a la orden por ruta tipada GET /v1/orders/sell/:id y /buy/:id, así el tipo de operación es visible en Network/logs sin abrir la respuesta.
- Cambio cosmético en /order/:id (compra) para alinear el fetch con el sell.

Made-with: Cursor